### PR TITLE
Fix the name of the error output

### DIFF
--- a/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/goal/fr.txt
+++ b/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/goal/fr.txt
@@ -37,7 +37,7 @@ COMMANDE  >  FICHIER
   (Le fichier est écrasé.)
 
 COMMANDE  2>  FICHIER
-  Envoie les messages d'erreurs (stdout) de la commande dans le 
+  Envoie les messages d'erreurs (stderr) de la commande dans le 
   fichier.
   (Le fichier est écrasé.)
 


### PR DESCRIPTION
"Messages d'erreur" est défini comme "stdout" à la ligne 40 et devrait être nommé "stderr"