### PR TITLE
Fix typo in documentation

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -57,7 +57,7 @@ directement dans le jeu.
 
 Quand vous quitterez le jeu (avec `control-d` ou la commande `gsh exit`) votre
 progression sera sauvegardée dans une nouvelle archive (nommée
-`GameShell-save.sh`). Elle peut être lancée pour reprendre le jeu où vous vous
+`gameshell-save.sh`). Elle peut être lancée pour reprendre le jeu où vous vous
 étiez arrêté.
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ game from the downloaded archive. Instructions on how to play are provided in
 the game directly.
 
 Note that when you quit the game (with `control-d` or the command `gsh exit`)
-your progression will be saved in a new archive (called `GameShell-save.sh`).
+your progression will be saved in a new archive (called `gameshell-save.sh`).
 Run this archive to resume the game where you left it.
 
 

--- a/doc/gameshell.md
+++ b/doc/gameshell.md
@@ -24,7 +24,7 @@ $ bash gameshell.sh
 ```
 
 Note that when you quit the game (with `control-d` or the command `gsh exit`)
-your progression will be saved in a new archive (called `GameShell-save.sh`).
+your progression will be saved in a new archive (called `gameshell-save.sh`).
 It can be run to resume the game where you left it.
 
 ### Using the start script in the source code


### PR DESCRIPTION
This fixes a typo in the documentation for restarting a saved game.