### PR TITLE
Use standard paths

### DIFF
--- a/lib/bashrc
+++ b/lib/bashrc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export HISTFILE="$GSH_CONFIG/history"
 export HISTSIZE=50000

--- a/lib/bin_test.sh
+++ b/lib/bin_test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 ### test the various utilities in GSH_ROOT/scripts/ directory
 

--- a/lib/gsh.sh
+++ b/lib/gsh.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # warning about "echo $(cmd)", used many times with echo "$(gettext ...)"
 # shellcheck disable=SC2005

--- a/lib/gshrc
+++ b/lib/gshrc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 unset LS_COLORS
 unset EDITOR

--- a/lib/header.sh
+++ b/lib/header.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$BASH_VERSION" ]
 then

--- a/lib/mission_source.sh
+++ b/lib/mission_source.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###
 # THIS FILE SHOULD BE SOURCED TO DEFINE THE mission_source FUNCTION.

--- a/lib/profile.sh
+++ b/lib/profile.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_ROOT" ] && echo "Error: GSH_ROOT undefined" && exit 1
 

--- a/lib/profile.sh
+++ b/lib/profile.sh
@@ -24,6 +24,11 @@ export GSH_SBIN="$GSH_ROOT/.sbin"
 export TEXTDOMAINDIR="$GSH_ROOT/locale"
 export TEXTDOMAIN="gsh"
 
+# keep a copy of the PATH before GSH's addition of GSH_ROOT
+# this is useful when a "real" command (e.g., rm) should be called instead of a GSH wrapper
+# a {:-} syntax is used so that PATH_NO_GSH is not modified if this file is sourced several times
+export PATH_NO_GSH="${PATH_NO_GSH:-${PATH}}"
+
 # putting $GSH_ROOT/bin first makes sure the local scripts are prefered over
 # system commands (realpath, seq, etc.). This is useful for testing, but
 # probably shouldn't be done for "stable" releases.

--- a/lib/zshrc
+++ b/lib/zshrc
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 export HISTFILE="$GSH_CONFIG/history"
 export HISTSIZE=50000

--- a/missions/FINAL_MISSION/check.sh
+++ b/missions/FINAL_MISSION/check.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 false

--- a/missions/FINAL_MISSION/goal.sh
+++ b/missions/FINAL_MISSION/goal.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 export password=$(gettext "qwerty")
 checksum "$password" > "$GSH_CONFIG/admin_hash"

--- a/missions/FINAL_MISSION/init.sh
+++ b/missions/FINAL_MISSION/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ "$GSH_MODE" = DEBUG ]
 then

--- a/missions/basic/01_cd_tower/auto.sh
+++ b/missions/basic/01_cd_tower/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cd "$(eval_gettext '$GSH_HOME/Castle/Main_tower/First_floor/Second_floor/Top_of_the_tower')"
 gsh check

--- a/missions/basic/01_cd_tower/check.sh
+++ b/missions/basic/01_cd_tower/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 goal=$(readlink-f "$(eval_gettext "\$GSH_HOME/Castle/Main_tower/First_floor/Second_floor/Top_of_the_tower")")
 current=$(readlink-f "$PWD")

--- a/missions/basic/01_cd_tower/init.sh
+++ b/missions/basic/01_cd_tower/init.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cd "$GSH_HOME"

--- a/missions/basic/01_cd_tower/static.sh
+++ b/missions/basic/01_cd_tower/static.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env sh
 mkdir -p "$(eval_gettext "\$GSH_HOME/Castle/Main_tower/First_floor/Second_floor/Top_of_the_tower")"

--- a/missions/basic/01_cd_tower/test.sh
+++ b/missions/basic/01_cd_tower/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh assert_check false
 

--- a/missions/basic/02_cd.._cellar/auto.sh
+++ b/missions/basic/02_cd.._cellar/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cd "$(eval_gettext "\$GSH_HOME/Castle/Cellar")"
 gsh check

--- a/missions/basic/02_cd.._cellar/check.sh
+++ b/missions/basic/02_cd.._cellar/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 goal=$(readlink-f "$(eval_gettext "\$GSH_HOME/Castle/Cellar")")
 current=$(readlink-f "$PWD")

--- a/missions/basic/02_cd.._cellar/static.sh
+++ b/missions/basic/02_cd.._cellar/static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Cellar')"
 sign_file "$MISSION_DIR/ascii-art/apple.txt" "$(eval_gettext '$GSH_HOME/Castle/Cellar')/$(gettext "barrel_of_apples")"

--- a/missions/basic/02_cd.._cellar/test.sh
+++ b/missions/basic/02_cd.._cellar/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cd
 gsh assert_check false

--- a/missions/basic/03_cd_HOME_throne/auto.sh
+++ b/missions/basic/03_cd_HOME_throne/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/basic/03_cd_HOME_throne/check.sh
+++ b/missions/basic/03_cd_HOME_throne/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # this should be POSIX compliant, but debian's sh (dash) doesn't have fc!
 

--- a/missions/basic/03_cd_HOME_throne/static.sh
+++ b/missions/basic/03_cd_HOME_throne/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room')"

--- a/missions/basic/03_cd_HOME_throne/test.sh
+++ b/missions/basic/03_cd_HOME_throne/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/basic/03_cd_HOME_throne/treasure.sh
+++ b/missions/basic/03_cd_HOME_throne/treasure.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 case "$GSH_SHELL" in
   *bash)

--- a/missions/basic/04_mkdir_chest/auto.sh
+++ b/missions/basic/04_mkdir_chest/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Forest")/$(gettext "Hut")/$(gettext "Chest")"
 gsh check

--- a/missions/basic/04_mkdir_chest/check.sh
+++ b/missions/basic/04_mkdir_chest/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     forest="$(eval_gettext '$GSH_HOME/Forest')"

--- a/missions/basic/04_mkdir_chest/clean.sh
+++ b/missions/basic/04_mkdir_chest/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 case $GSH_LAST_ACTION in
   check_true)

--- a/missions/basic/04_mkdir_chest/static.sh
+++ b/missions/basic/04_mkdir_chest/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Forest")"

--- a/missions/basic/04_mkdir_chest/test.sh
+++ b/missions/basic/04_mkdir_chest/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 find "$GSH_HOME" -iname "*$(gettext "Hut")*" -print0 | xargs -0 rm -rf
 find "$GSH_HOME" -iname "*$(gettext "Chest")*" -print0 | xargs -0 rm -rf

--- a/missions/basic/05_rm_spiders_cellar/auto.sh
+++ b/missions/basic/05_rm_spiders_cellar/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm "$(eval_gettext '$GSH_HOME/Castle/Cellar')/$(gettext "spider")"_?
 gsh check

--- a/missions/basic/05_rm_spiders_cellar/check.sh
+++ b/missions/basic/05_rm_spiders_cellar/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     cellar="$(eval_gettext '$GSH_HOME/Castle/Cellar')"

--- a/missions/basic/05_rm_spiders_cellar/init.sh
+++ b/missions/basic/05_rm_spiders_cellar/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   for i in $(seq 3)

--- a/missions/basic/05_rm_spiders_cellar/static.sh
+++ b/missions/basic/05_rm_spiders_cellar/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Castle/Cellar")"

--- a/missions/basic/05_rm_spiders_cellar/test.sh
+++ b/missions/basic/05_rm_spiders_cellar/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh assert check false
 

--- a/missions/basic/06_mv_coins_garden/auto.sh
+++ b/missions/basic/06_mv_coins_garden/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mv "$(eval_gettext '$GSH_HOME/Garden')/$(gettext "coin")_"? "$GSH_CHEST"
 gsh check

--- a/missions/basic/06_mv_coins_garden/check.sh
+++ b/missions/basic/06_mv_coins_garden/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Receives coin number as first argument.
 _mission_check() (

--- a/missions/basic/06_mv_coins_garden/init.sh
+++ b/missions/basic/06_mv_coins_garden/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/basic/06_mv_coins_garden/static.sh
+++ b/missions/basic/06_mv_coins_garden/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Garden")"

--- a/missions/basic/06_mv_coins_garden/test.sh
+++ b/missions/basic/06_mv_coins_garden/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mv "$(eval_gettext '$GSH_HOME/Garden')/$(gettext "coin")_"2 "$GSH_CHEST"
 gsh assert check false

--- a/missions/basic/07_mv_hidden_coins_garden/auto.sh
+++ b/missions/basic/07_mv_hidden_coins_garden/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mv "$(eval_gettext '$GSH_HOME/Garden')/".*_"$(gettext "coin")"_* "$GSH_CHEST"
 gsh check

--- a/missions/basic/07_mv_hidden_coins_garden/check.sh
+++ b/missions/basic/07_mv_hidden_coins_garden/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Receives coin number as first argument.
 _mission_check() (

--- a/missions/basic/07_mv_hidden_coins_garden/clean.sh
+++ b/missions/basic/07_mv_hidden_coins_garden/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 case "$GSH_LAST_ACTION" in
     "check_true")

--- a/missions/basic/07_mv_hidden_coins_garden/init.sh
+++ b/missions/basic/07_mv_hidden_coins_garden/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/basic/07_mv_hidden_coins_garden/static.sh
+++ b/missions/basic/07_mv_hidden_coins_garden/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Garden")"

--- a/missions/basic/07_mv_hidden_coins_garden/test.sh
+++ b/missions/basic/07_mv_hidden_coins_garden/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mv "$(eval_gettext '$GSH_HOME/Garden')/".*_"$(gettext "coin")_2" "$GSH_CHEST"
 gsh assert check false

--- a/missions/basic/08_rm_wildcard_spiders_cellar/auto.sh
+++ b/missions/basic/08_rm_wildcard_spiders_cellar/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$(eval_gettext '$GSH_HOME/Castle/Cellar')/"*_"$(gettext "spider")"_*
 gsh check

--- a/missions/basic/08_rm_wildcard_spiders_cellar/check.sh
+++ b/missions/basic/08_rm_wildcard_spiders_cellar/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     CELLAR="$(eval_gettext "\$GSH_HOME/Castle/Cellar")"

--- a/missions/basic/08_rm_wildcard_spiders_cellar/clean.sh
+++ b/missions/basic/08_rm_wildcard_spiders_cellar/clean.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_TMP/bats"

--- a/missions/basic/08_rm_wildcard_spiders_cellar/init.sh
+++ b/missions/basic/08_rm_wildcard_spiders_cellar/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   if ! [ -e "$MISSION_DIR/ascii-art" ]

--- a/missions/basic/08_rm_wildcard_spiders_cellar/static.sh
+++ b/missions/basic/08_rm_wildcard_spiders_cellar/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Castle/Cellar")"

--- a/missions/basic/08_rm_wildcard_spiders_cellar/test.sh
+++ b/missions/basic/08_rm_wildcard_spiders_cellar/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh assert check false
 

--- a/missions/basic/09_rm_wildcard_hidden_spiders_cellar/auto.sh
+++ b/missions/basic/09_rm_wildcard_hidden_spiders_cellar/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$(eval_gettext '$GSH_HOME/Castle/Cellar')/".*_"$(gettext "spider")"_*
 gsh check

--- a/missions/basic/09_rm_wildcard_hidden_spiders_cellar/check.sh
+++ b/missions/basic/09_rm_wildcard_hidden_spiders_cellar/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   CELLAR="$(eval_gettext "\$GSH_HOME/Castle/Cellar")"

--- a/missions/basic/09_rm_wildcard_hidden_spiders_cellar/clean.sh
+++ b/missions/basic/09_rm_wildcard_hidden_spiders_cellar/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_TMP/bats"
 

--- a/missions/basic/09_rm_wildcard_hidden_spiders_cellar/init.sh
+++ b/missions/basic/09_rm_wildcard_hidden_spiders_cellar/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   if ! [ -e "$MISSION_DIR/ascii-art" ]

--- a/missions/basic/09_rm_wildcard_hidden_spiders_cellar/static.sh
+++ b/missions/basic/09_rm_wildcard_hidden_spiders_cellar/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Castle/Cellar")"

--- a/missions/basic/09_rm_wildcard_hidden_spiders_cellar/test.sh
+++ b/missions/basic/09_rm_wildcard_hidden_spiders_cellar/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh assert check false
 

--- a/missions/basic/09_rm_wildcard_hidden_spiders_cellar/treasure.sh
+++ b/missions/basic/09_rm_wildcard_hidden_spiders_cellar/treasure.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # NOTE: --literal doesn't exist in freebsd
 if ls --literal / >/dev/null 2>/dev/null

--- a/missions/basic/10_cp_standard_great_hall/auto.sh
+++ b/missions/basic/10_cp_standard_great_hall/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cp "$(eval_gettext '$GSH_HOME/Castle/Great_hall')/$(gettext "standard")"_? "$GSH_CHEST"
 gsh check

--- a/missions/basic/10_cp_standard_great_hall/check.sh
+++ b/missions/basic/10_cp_standard_great_hall/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/basic/10_cp_standard_great_hall/clean.sh
+++ b/missions/basic/10_cp_standard_great_hall/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mission_source "$MISSION_DIR/clean0.sh"
 

--- a/missions/basic/10_cp_standard_great_hall/clean0.sh
+++ b/missions/basic/10_cp_standard_great_hall/clean0.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 case "$GSH_LAST_ACTION" in
   check_true | skip)

--- a/missions/basic/10_cp_standard_great_hall/init.sh
+++ b/missions/basic/10_cp_standard_great_hall/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/basic/10_cp_standard_great_hall/init0.sh
+++ b/missions/basic/10_cp_standard_great_hall/init0.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init0() (
   great_hall="$(eval_gettext '$GSH_HOME/Castle/Great_hall')"

--- a/missions/basic/10_cp_standard_great_hall/static.sh
+++ b/missions/basic/10_cp_standard_great_hall/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Castle/Great_hall")"

--- a/missions/basic/10_cp_standard_great_hall/test.sh
+++ b/missions/basic/10_cp_standard_great_hall/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cp "$(eval_gettext '$GSH_HOME/Castle/Great_hall')/$(gettext "standard")"_? "$GSH_CHEST"
 gsh assert check true

--- a/missions/basic/11_cp_wildcards_tapestries_great_hall/auto.sh
+++ b/missions/basic/11_cp_wildcards_tapestries_great_hall/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cp "$(eval_gettext '$GSH_HOME/Castle/Great_hall')"/*"$(gettext "tapestry")"* "$GSH_CHEST"
 gsh check

--- a/missions/basic/11_cp_wildcards_tapestries_great_hall/check.sh
+++ b/missions/basic/11_cp_wildcards_tapestries_great_hall/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check () (
   GREAT_HALL="$(eval_gettext '$GSH_HOME/Castle/Great_hall')"

--- a/missions/basic/11_cp_wildcards_tapestries_great_hall/clean.sh
+++ b/missions/basic/11_cp_wildcards_tapestries_great_hall/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mission_source "$MISSION_DIR"/clean0.sh
 

--- a/missions/basic/11_cp_wildcards_tapestries_great_hall/init.sh
+++ b/missions/basic/11_cp_wildcards_tapestries_great_hall/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/basic/11_cp_wildcards_tapestries_great_hall/static.sh
+++ b/missions/basic/11_cp_wildcards_tapestries_great_hall/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Castle/Great_hall")"

--- a/missions/basic/11_cp_wildcards_tapestries_great_hall/test.sh
+++ b/missions/basic/11_cp_wildcards_tapestries_great_hall/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cp "$(eval_gettext '$GSH_HOME/Castle/Great_hall')"/*"$(gettext "tapestry")"* "$GSH_CHEST"
 gsh assert check true

--- a/missions/basic/12_cp_ls_mtime_paintings_tower/auto.sh
+++ b/missions/basic/12_cp_ls_mtime_paintings_tower/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 filename=$(head -n1 "$GSH_TMP/painting")
 

--- a/missions/basic/12_cp_ls_mtime_paintings_tower/check.sh
+++ b/missions/basic/12_cp_ls_mtime_paintings_tower/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     filename="$(head -n1 "$GSH_TMP/painting")"

--- a/missions/basic/12_cp_ls_mtime_paintings_tower/clean.sh
+++ b/missions/basic/12_cp_ls_mtime_paintings_tower/clean.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_TMP/painting"

--- a/missions/basic/12_cp_ls_mtime_paintings_tower/init.sh
+++ b/missions/basic/12_cp_ls_mtime_paintings_tower/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/basic/12_cp_ls_mtime_paintings_tower/static.sh
+++ b/missions/basic/12_cp_ls_mtime_paintings_tower/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Castle/Main_tower/First_floor")"

--- a/missions/basic/12_cp_ls_mtime_paintings_tower/test.sh
+++ b/missions/basic/12_cp_ls_mtime_paintings_tower/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cp "$(eval_gettext '$GSH_HOME/Castle/Main_tower/First_floor')/$(head -n1 "$GSH_TMP/painting")" "$GSH_CHEST"
 gsh assert check true

--- a/missions/finding_files_maze/00_shared/clean.sh
+++ b/missions/finding_files_maze/00_shared/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 maze="$(eval_gettext '$GSH_HOME/Garden/Maze')"
 case $(pwd -P) in

--- a/missions/finding_files_maze/00_shared/sbin/generate_maze.sh
+++ b/missions/finding_files_maze/00_shared/sbin/generate_maze.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 DIR=$1
 DEPTH=$2

--- a/missions/finding_files_maze/00_shared/static.sh
+++ b/missions/finding_files_maze/00_shared/static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Garden/Maze')"
 mkdir -p "$(eval_gettext '$GSH_HOME/Garden/Flower_garden')"

--- a/missions/finding_files_maze/01_ls_cd/auto.sh
+++ b/missions/finding_files_maze/01_ls_cd/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 (
   cd "$(eval_gettext '$GSH_HOME/Garden/Maze')"

--- a/missions/finding_files_maze/01_ls_cd/check.sh
+++ b/missions/finding_files_maze/01_ls_cd/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     maze="$(eval_gettext '$GSH_HOME/Garden/Maze')"

--- a/missions/finding_files_maze/01_ls_cd/clean.sh
+++ b/missions/finding_files_maze/01_ls_cd/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # protect the root directory
 [ "$GSH_MODE" != "DEBUG" ] && ! [ -d "$GSH_ROOT/.git" ] && gsh protect

--- a/missions/finding_files_maze/01_ls_cd/goal.sh
+++ b/missions/finding_files_maze/01_ls_cd/goal.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 maze="$(eval_gettext '$GSH_HOME/Garden/Maze')"
 # NOTE: POSIX sed doesn't support using another character than '/' in "s/.../.../"

--- a/missions/finding_files_maze/01_ls_cd/init.sh
+++ b/missions/finding_files_maze/01_ls_cd/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/finding_files_maze/01_ls_cd/test.sh
+++ b/missions/finding_files_maze/01_ls_cd/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 (
   gsh assert check false

--- a/missions/finding_files_maze/01_ls_cd/treasure-msg.sh
+++ b/missions/finding_files_maze/01_ls_cd/treasure-msg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if command ls --color >/dev/null 2>/dev/null
 then

--- a/missions/finding_files_maze/01_ls_cd/treasure.sh
+++ b/missions/finding_files_maze/01_ls_cd/treasure.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # NOTE: --literal doesn't exist in freebsd
 #       --color doesn't exist in macos, it is replaced by -G

--- a/missions/finding_files_maze/02_tree/auto.sh
+++ b/missions/finding_files_maze/02_tree/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 (
   cd "$(eval_gettext '$GSH_HOME/Garden/Maze')"

--- a/missions/finding_files_maze/02_tree/check.sh
+++ b/missions/finding_files_maze/02_tree/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     maze="$(eval_gettext '$GSH_HOME/Garden/Maze')"

--- a/missions/finding_files_maze/02_tree/clean.sh
+++ b/missions/finding_files_maze/02_tree/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . "$MISSION_DIR/../00_shared/clean.sh"
 rm -f "$GSH_TMP/silver_coin"

--- a/missions/finding_files_maze/02_tree/init.sh
+++ b/missions/finding_files_maze/02_tree/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/finding_files_maze/02_tree/test.sh
+++ b/missions/finding_files_maze/02_tree/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh assert check false
 

--- a/missions/finding_files_maze/03_find_1/auto.sh
+++ b/missions/finding_files_maze/03_find_1/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 (
   cd "$(eval_gettext '$GSH_HOME/Garden/Maze')"

--- a/missions/finding_files_maze/03_find_1/check.sh
+++ b/missions/finding_files_maze/03_find_1/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check_p() (
     coin_name=$1

--- a/missions/finding_files_maze/03_find_1/clean.sh
+++ b/missions/finding_files_maze/03_find_1/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . "$MISSION_DIR/../00_shared/clean.sh"
 rm -f "$GSH_TMP"/gold_coin_* "$GSH_TMP"/GolD_CoiN_*

--- a/missions/finding_files_maze/03_find_1/init.sh
+++ b/missions/finding_files_maze/03_find_1/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/finding_files_maze/03_find_1/test.sh
+++ b/missions/finding_files_maze/03_find_1/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh assert check false
 

--- a/missions/finding_files_maze/04_find_2/auto.sh
+++ b/missions/finding_files_maze/04_find_2/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 (
   cd "$(eval_gettext '$GSH_HOME/Garden/Maze')"

--- a/missions/finding_files_maze/04_find_2/check.sh
+++ b/missions/finding_files_maze/04_find_2/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     maze="$(eval_gettext '$GSH_HOME/Garden/Maze')"

--- a/missions/finding_files_maze/04_find_2/clean.sh
+++ b/missions/finding_files_maze/04_find_2/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . "$MISSION_DIR/../00_shared/clean.sh"
 rm -f "$GSH_TMP/ruby"

--- a/missions/finding_files_maze/04_find_2/init.sh
+++ b/missions/finding_files_maze/04_find_2/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/finding_files_maze/04_find_2/test.sh
+++ b/missions/finding_files_maze/04_find_2/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh assert check false
 

--- a/missions/finding_files_maze/05_find_xargs_grep/auto.sh
+++ b/missions/finding_files_maze/05_find_xargs_grep/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 (
   cd "$(eval_gettext '$GSH_HOME/Garden/Maze')"

--- a/missions/finding_files_maze/05_find_xargs_grep/check.sh
+++ b/missions/finding_files_maze/05_find_xargs_grep/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     maze="$(eval_gettext '$GSH_HOME/Garden/Maze')"

--- a/missions/finding_files_maze/05_find_xargs_grep/clean.sh
+++ b/missions/finding_files_maze/05_find_xargs_grep/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . "$MISSION_DIR/../00_shared/clean.sh"
 rm -f "$GSH_TMP/diamond"

--- a/missions/finding_files_maze/05_find_xargs_grep/init.sh
+++ b/missions/finding_files_maze/05_find_xargs_grep/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/finding_files_maze/05_find_xargs_grep/test.sh
+++ b/missions/finding_files_maze/05_find_xargs_grep/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh assert check false
 

--- a/missions/intermediate/01_alias_la/auto.sh
+++ b/missions/intermediate/01_alias_la/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 alias la="ls -A"
 gsh check

--- a/missions/intermediate/01_alias_la/check.sh
+++ b/missions/intermediate/01_alias_la/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # "local" is not in POSIX, and function cannot be in a subshell as it needs
 # access to aliases defined in the main shell.

--- a/missions/intermediate/01_alias_la/goal.sh
+++ b/missions/intermediate/01_alias_la/goal.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cp "$MISSION_DIR/ascii-art/diamond.txt" ./".$(gettext "nice_rock")"
 cat "$(eval_gettext '$MISSION_DIR/goal/en.txt')"

--- a/missions/intermediate/01_alias_la/test.sh
+++ b/missions/intermediate/01_alias_la/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 alias la="ls -A"
 gsh assert check true

--- a/missions/intermediate/01_alias_la/treasure.sh
+++ b/missions/intermediate/01_alias_la/treasure.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # NOTE: --literal doesn't exist in freebsd
 if ls --literal / >/dev/null 2>/dev/null

--- a/missions/intermediate/02_alias_journal/auto.sh
+++ b/missions/intermediate/02_alias_journal/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 alias "$(gettext "journal")"="nano \"\$GSH_CHEST/$(gettext "journal").txt\""
 gsh check

--- a/missions/intermediate/02_alias_journal/check.sh
+++ b/missions/intermediate/02_alias_journal/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # function cannot be in a subshell because it needs access to aliases defined
 # in the main shell.

--- a/missions/intermediate/02_alias_journal/clean.sh
+++ b/missions/intermediate/02_alias_journal/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 case "$GSH_LAST_ACTION" in
   "check_true")

--- a/missions/intermediate/02_alias_journal/init.sh
+++ b/missions/intermediate/02_alias_journal/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if ! command -v nano >/dev/null; then
   echo "$(eval_gettext "The command 'nano' is required for mission \$MISSION_NAME.

--- a/missions/intermediate/02_alias_journal/test.sh
+++ b/missions/intermediate/02_alias_journal/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 alias "$(gettext "journal")"="nano \"$GSH_CHEST/$(gettext "journal").txt\""
 gsh assert check true

--- a/missions/intermediate/02_alias_journal/treasure.sh
+++ b/missions/intermediate/02_alias_journal/treasure.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 alias "$(gettext "journal")"="nano '$GSH_CHEST/$(gettext "journal").txt'"
 

--- a/missions/intermediate/03_tab_spider_lair/auto.sh
+++ b/missions/intermediate/03_tab_spider_lair/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 lair="$(find "$(eval_gettext '$GSH_HOME/Castle/Cellar')" -type d -name ".$(gettext "Lair_of_the_spider_queen")*")"
 cd "$lair"

--- a/missions/intermediate/03_tab_spider_lair/check.sh
+++ b/missions/intermediate/03_tab_spider_lair/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
 

--- a/missions/intermediate/03_tab_spider_lair/clean.sh
+++ b/missions/intermediate/03_tab_spider_lair/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set +o noglob
 rm -f "$GSH_TMP/start_time"

--- a/missions/intermediate/03_tab_spider_lair/init.sh
+++ b/missions/intermediate/03_tab_spider_lair/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   r1=$(random_string 16)

--- a/missions/intermediate/03_tab_spider_lair/static.sh
+++ b/missions/intermediate/03_tab_spider_lair/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext "\$GSH_HOME/Castle/Cellar")"

--- a/missions/intermediate/03_tab_spider_lair/test.sh
+++ b/missions/intermediate/03_tab_spider_lair/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cd
 gsh assert check false

--- a/missions/intermediate/04_bg_xeyes/auto.sh
+++ b/missions/intermediate/04_bg_xeyes/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/intermediate/04_bg_xeyes/check.sh
+++ b/missions/intermediate/04_bg_xeyes/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # fc in specified in POSIX, but debian's sh doesn't implement it!
 

--- a/missions/intermediate/04_bg_xeyes/init.sh
+++ b/missions/intermediate/04_bg_xeyes/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ -z "$DISPLAY" ]; then
   echo "$(eval_gettext "The variable DISPLAY is not defined.

--- a/missions/intermediate/04_bg_xeyes/test.sh
+++ b/missions/intermediate/04_bg_xeyes/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . alt_history_start.sh
 

--- a/missions/misc/01_cal_nostradamus/auto.sh
+++ b/missions/misc/01_cal_nostradamus/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_auto() (
   YYYY=$(cut -d"-" -f1 "$GSH_TMP"/date)

--- a/missions/misc/01_cal_nostradamus/check.sh
+++ b/missions/misc/01_cal_nostradamus/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   DOW() (

--- a/missions/misc/01_cal_nostradamus/clean.sh
+++ b/missions/misc/01_cal_nostradamus/clean.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_TMP"/date

--- a/missions/misc/01_cal_nostradamus/goal.sh
+++ b/missions/misc/01_cal_nostradamus/goal.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 YYYY=$(cut -d"-" -f1 "$GSH_TMP"/date)
 MM=$(cut -d"-" -f2 "$GSH_TMP"/date)

--- a/missions/misc/01_cal_nostradamus/init.sh
+++ b/missions/misc/01_cal_nostradamus/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   if ! command -v cal >/dev/null; then

--- a/missions/misc/01_cal_nostradamus/test.sh
+++ b/missions/misc/01_cal_nostradamus/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _DOW() (
     if dow=$(date --date="$1" +%A 2> /dev/null)

--- a/missions/misc/02_nano_journal/auto.sh
+++ b/missions/misc/02_nano_journal/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$GSH_CHEST"
 echo "I'll be back." > "$GSH_CHEST/$(gettext "journal").txt"

--- a/missions/misc/02_nano_journal/check.sh
+++ b/missions/misc/02_nano_journal/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     journal_file="$GSH_CHEST/$(gettext "journal").txt"

--- a/missions/misc/02_nano_journal/init.sh
+++ b/missions/misc/02_nano_journal/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if ! command -v nano >/dev/null; then
   echo "$(eval_gettext "The command 'nano' is required for mission \$MISSION_NAME.

--- a/missions/misc/02_nano_journal/test.sh
+++ b/missions/misc/02_nano_journal/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_CHEST/$(gettext "journal").txt"
 gsh assert check false

--- a/missions/misc/03_tr_caesar_shift/auto.sh
+++ b/missions/misc/03_tr_caesar_shift/auto.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh check < "$GSH_TMP/magic_word"

--- a/missions/misc/03_tr_caesar_shift/check.sh
+++ b/missions/misc/03_tr_caesar_shift/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 echo "$(gettext "What's the key that will make Merlin's chest to appear?")"
 read -r dcode

--- a/missions/misc/03_tr_caesar_shift/clean.sh
+++ b/missions/misc/03_tr_caesar_shift/clean.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_TMP/magic_word"

--- a/missions/misc/03_tr_caesar_shift/init.sh
+++ b/missions/misc/03_tr_caesar_shift/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # mission originaly created by Tiemen Duvillard
 

--- a/missions/misc/03_tr_caesar_shift/static.sh
+++ b/missions/misc/03_tr_caesar_shift/static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office/Drawer')"
 sign_file "$MISSION_DIR/ascii-art/ink_scroll.txt" "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office/Drawer')/$(gettext "ink_and_scroll")"

--- a/missions/permissions/01_chmod_x_dir_king_quarter/auto.sh
+++ b/missions/permissions/01_chmod_x_dir_king_quarter/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 chmod +x "$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room/Kings_quarter')"
 cd "$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room/Kings_quarter')"

--- a/missions/permissions/01_chmod_x_dir_king_quarter/check.sh
+++ b/missions/permissions/01_chmod_x_dir_king_quarter/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 dir=$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room/Kings_quarter')
 

--- a/missions/permissions/01_chmod_x_dir_king_quarter/clean.sh
+++ b/missions/permissions/01_chmod_x_dir_king_quarter/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 king_quarter=$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room/Kings_quarter')
 

--- a/missions/permissions/01_chmod_x_dir_king_quarter/init.sh
+++ b/missions/permissions/01_chmod_x_dir_king_quarter/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   if ! command -v man >/dev/null; then

--- a/missions/permissions/01_chmod_x_dir_king_quarter/static.sh
+++ b/missions/permissions/01_chmod_x_dir_king_quarter/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room/Kings_quarter')"

--- a/missions/permissions/01_chmod_x_dir_king_quarter/test.sh
+++ b/missions/permissions/01_chmod_x_dir_king_quarter/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh assert check false
 

--- a/missions/permissions/02_chmod_r_file_king_quarter/auto.sh
+++ b/missions/permissions/02_chmod_r_file_king_quarter/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 dir=$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room/Kings_quarter')
 chmod +r "$dir/.$(gettext "secret_note")"

--- a/missions/permissions/02_chmod_r_file_king_quarter/check.sh
+++ b/missions/permissions/02_chmod_r_file_king_quarter/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 printf "%s " "$(gettext "What's the combination to open the King's safe?")"
 read -r key

--- a/missions/permissions/02_chmod_r_file_king_quarter/clean.sh
+++ b/missions/permissions/02_chmod_r_file_king_quarter/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # avoid problems when making a tar archive
 chmod +r "$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room/Kings_quarter')/.$(gettext "secret_note")"

--- a/missions/permissions/02_chmod_r_file_king_quarter/init.sh
+++ b/missions/permissions/02_chmod_r_file_king_quarter/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   if ! command -v man >/dev/null; then

--- a/missions/permissions/02_chmod_r_file_king_quarter/static.sh
+++ b/missions/permissions/02_chmod_r_file_king_quarter/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room/Kings_quarter')"

--- a/missions/permissions/02_chmod_r_file_king_quarter/test.sh
+++ b/missions/permissions/02_chmod_r_file_king_quarter/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 dir=$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room/Kings_quarter')
 chmod +r "$dir/.$(gettext "secret_note")"

--- a/missions/permissions/03_chmod_rw_file_dir_throne_room/auto.sh
+++ b/missions/permissions/03_chmod_rw_file_dir_throne_room/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 safedir="$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room')/$(gettext "Safe")"
 chmod 755 "$safedir"

--- a/missions/permissions/03_chmod_rw_file_dir_throne_room/check.sh
+++ b/missions/permissions/03_chmod_rw_file_dir_throne_room/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   if ! [ -f "$GSH_CHEST/$(gettext "crown")" ]

--- a/missions/permissions/03_chmod_rw_file_dir_throne_room/clean.sh
+++ b/missions/permissions/03_chmod_rw_file_dir_throne_room/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 safe="$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room')/$(gettext "Safe")"
 

--- a/missions/permissions/03_chmod_rw_file_dir_throne_room/init.sh
+++ b/missions/permissions/03_chmod_rw_file_dir_throne_room/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 [ -z "$GSH_CHEST" ] && GSH_CHEST="$(eval_gettext '$GSH_HOME/Forest/Hut/Chest')"
 mkdir -p "$GSH_CHEST"

--- a/missions/permissions/03_chmod_rw_file_dir_throne_room/static.sh
+++ b/missions/permissions/03_chmod_rw_file_dir_throne_room/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room')"

--- a/missions/permissions/03_chmod_rw_file_dir_throne_room/test.sh
+++ b/missions/permissions/03_chmod_rw_file_dir_throne_room/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 
 gsh assert check false

--- a/missions/pipe_intro_book_of_potions/00_shared/clean.sh
+++ b/missions/pipe_intro_book_of_potions/00_shared/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$(eval_gettext '$GSH_HOME/Mountain/Cave')/servillus"
 sign_file "$MISSION_DIR/ascii-art/cauldron.txt" "$(eval_gettext '$GSH_HOME/Mountain/Cave')/$(gettext "cauldron")"

--- a/missions/pipe_intro_book_of_potions/00_shared/init.sh
+++ b/missions/pipe_intro_book_of_potions/00_shared/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   if ! command -v install_potion_book.sh >/dev/null

--- a/missions/pipe_intro_book_of_potions/00_shared/sbin/install_potion_book.sh
+++ b/missions/pipe_intro_book_of_potions/00_shared/sbin/install_potion_book.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/missions/pipe_intro_book_of_potions/00_shared/static.sh
+++ b/missions/pipe_intro_book_of_potions/00_shared/static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Mountain/Cave')"
 sign_file "$MISSION_DIR/ascii-art/cauldron.txt" "$(eval_gettext '$GSH_HOME/Mountain/Cave')/$(gettext "cauldron")"

--- a/missions/pipe_intro_book_of_potions/01_head/auto.sh
+++ b/missions/pipe_intro_book_of_potions/01_head/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipe_intro_book_of_potions/01_head/check.sh
+++ b/missions/pipe_intro_book_of_potions/01_head/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   cave="$(eval_gettext '$GSH_HOME/Mountain/Cave')"

--- a/missions/pipe_intro_book_of_potions/01_head/test.sh
+++ b/missions/pipe_intro_book_of_potions/01_head/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipe_intro_book_of_potions/02_tail/auto.sh
+++ b/missions/pipe_intro_book_of_potions/02_tail/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipe_intro_book_of_potions/02_tail/check.sh
+++ b/missions/pipe_intro_book_of_potions/02_tail/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   cave="$(eval_gettext '$GSH_HOME/Mountain/Cave')"

--- a/missions/pipe_intro_book_of_potions/02_tail/test.sh
+++ b/missions/pipe_intro_book_of_potions/02_tail/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipe_intro_book_of_potions/03_cat/auto.sh
+++ b/missions/pipe_intro_book_of_potions/03_cat/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipe_intro_book_of_potions/03_cat/check.sh
+++ b/missions/pipe_intro_book_of_potions/03_cat/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   cave="$(eval_gettext '$GSH_HOME/Mountain/Cave')"

--- a/missions/pipe_intro_book_of_potions/03_cat/test.sh
+++ b/missions/pipe_intro_book_of_potions/03_cat/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipe_intro_book_of_potions/04_pipe/auto.sh
+++ b/missions/pipe_intro_book_of_potions/04_pipe/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipe_intro_book_of_potions/04_pipe/check.sh
+++ b/missions/pipe_intro_book_of_potions/04_pipe/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   cave="$(eval_gettext '$GSH_HOME/Mountain/Cave')"

--- a/missions/pipe_intro_book_of_potions/04_pipe/test.sh
+++ b/missions/pipe_intro_book_of_potions/04_pipe/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipe_intro_book_of_potions/05_pipe_head_tail/auto.sh
+++ b/missions/pipe_intro_book_of_potions/05_pipe_head_tail/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipe_intro_book_of_potions/05_pipe_head_tail/check.sh
+++ b/missions/pipe_intro_book_of_potions/05_pipe_head_tail/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   cave="$(eval_gettext '$GSH_HOME/Mountain/Cave')"

--- a/missions/pipe_intro_book_of_potions/05_pipe_head_tail/test.sh
+++ b/missions/pipe_intro_book_of_potions/05_pipe_head_tail/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/pipes_merchant_stall/00_shared/clean.sh
+++ b/missions/pipes_merchant_stall/00_shared/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # need to be careful, as there are so many files in the Stall that
 # rm Stall/* may not work.

--- a/missions/pipes_merchant_stall/00_shared/count_commands.sh
+++ b/missions/pipes_merchant_stall/00_shared/count_commands.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # NOTE: debian's sh (dash) is compiled without fc, so this won't work!
 

--- a/missions/pipes_merchant_stall/00_shared/sbin/generate_merchant_stall.sh
+++ b/missions/pipes_merchant_stall/00_shared/sbin/generate_merchant_stall.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/missions/pipes_merchant_stall/00_shared/static.sh
+++ b/missions/pipes_merchant_stall/00_shared/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Stall')"

--- a/missions/pipes_merchant_stall/01_pipe_1/auto.sh
+++ b/missions/pipes_merchant_stall/01_pipe_1/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # FIXME? I use bash' process substitution to avoid creating a subshell
 

--- a/missions/pipes_merchant_stall/01_pipe_1/check.sh
+++ b/missions/pipes_merchant_stall/01_pipe_1/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   amount=$(cat "$GSH_TMP/amountKing")

--- a/missions/pipes_merchant_stall/01_pipe_1/init.sh
+++ b/missions/pipes_merchant_stall/01_pipe_1/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() {
   if ! command -v generate_merchant_stall.sh >/dev/null

--- a/missions/pipes_merchant_stall/02_pipe_2/auto.sh
+++ b/missions/pipes_merchant_stall/02_pipe_2/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # FIXME? I use bash' process substitution to avoid creating a subshell
 

--- a/missions/pipes_merchant_stall/02_pipe_2/check.sh
+++ b/missions/pipes_merchant_stall/02_pipe_2/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   nb_unpaid=$(cat "$GSH_TMP/nbUnpaid")

--- a/missions/pipes_merchant_stall/02_pipe_2/init.sh
+++ b/missions/pipes_merchant_stall/02_pipe_2/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() {
   if ! command -v generate_merchant_stall.sh >/dev/null

--- a/missions/processes/00_shared/init.sh
+++ b/missions/processes/00_shared/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # use a subshell, that should guarantee that no message is displayed when the
 # test-proc-name process is killed.

--- a/missions/processes/00_shared/my_ps-linux
+++ b/missions/processes/00_shared/my_ps-linux
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ -z "$*" ]
 then

--- a/missions/processes/00_shared/my_ps-macos
+++ b/missions/processes/00_shared/my_ps-macos
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ -z "$*" ]
 then

--- a/missions/processes/00_shared/static.sh
+++ b/missions/processes/00_shared/static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # for some unkwnown reason, `ps -o pid,ppid,comm` doesn't find any process
 # on the "macos-latest" image on github.

--- a/missions/processes/00_shared/test-proc-name.sh
+++ b/missions/processes/00_shared/test-proc-name.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env sh
 sleep 100

--- a/missions/processes/01_ps_kill/auto.sh
+++ b/missions/processes/01_ps_kill/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 my_ps | awk -v spell="$(gettext "spell")" '$0 ~ spell {print $1}' | xargs kill -9 2> /dev/null
 sleep 1

--- a/missions/processes/01_ps_kill/check.sh
+++ b/missions/processes/01_ps_kill/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   if my_ps $(cat "$GSH_TMP/spell.pid") | grep -q "$(gettext "spell")"

--- a/missions/processes/01_ps_kill/clean.sh
+++ b/missions/processes/01_ps_kill/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 kill -9 "$(cat "$GSH_TMP/spell.pid")" 2>/dev/null
 my_ps | awk '/sleep|tail/ {print $1}' | xargs kill -9 2>/dev/null

--- a/missions/processes/01_ps_kill/goal.sh
+++ b/missions/processes/01_ps_kill/goal.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 export PS
 if ps -c | head -n1 | grep CLS 2>/dev/null >/dev/null

--- a/missions/processes/01_ps_kill/init.sh
+++ b/missions/processes/01_ps_kill/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _compile() (
   if command -v gcc >/dev/null

--- a/missions/processes/01_ps_kill/spell.sh
+++ b/missions/processes/01_ps_kill/spell.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 trap clean TERM
 

--- a/missions/processes/01_ps_kill/test.sh
+++ b/missions/processes/01_ps_kill/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 my_ps | awk -v spell="$(gettext "spell")" '$0 ~ spell {print $1}' | xargs kill -9 2>/dev/null
 sleep 1

--- a/missions/processes/02_ps_kill_signal/auto.sh
+++ b/missions/processes/02_ps_kill_signal/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 my_ps | awk -v spell="$(gettext "spell")" '$0 ~ spell {print $1}' | xargs kill 2>/dev/null
 sleep 1

--- a/missions/processes/02_ps_kill_signal/check.sh
+++ b/missions/processes/02_ps_kill_signal/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   nb_spells=$(my_ps | grep -c "$(gettext "spell")" | tr -d ' ')

--- a/missions/processes/02_ps_kill_signal/clean.sh
+++ b/missions/processes/02_ps_kill_signal/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 kill -9 $(cat "$GSH_TMP/spell-term.pids" 2>/dev/null) 2>/dev/null
 kill -9 $(cat "$GSH_TMP/spell.pids" 2>/dev/null) 2>/dev/null

--- a/missions/processes/02_ps_kill_signal/goal.sh
+++ b/missions/processes/02_ps_kill_signal/goal.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 export PS
 if ps -c | head -n1 | grep CLS 2>/dev/null >/dev/null

--- a/missions/processes/02_ps_kill_signal/init.sh
+++ b/missions/processes/02_ps_kill_signal/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _compile() (
 

--- a/missions/processes/02_ps_kill_signal/spell.sh
+++ b/missions/processes/02_ps_kill_signal/spell.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/missions/processes/02_ps_kill_signal/test.sh
+++ b/missions/processes/02_ps_kill_signal/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 my_ps | awk -v spell="$(gettext "spell")" '$0 ~ spell {print $1}' | xargs kill 2> /dev/null
 sleep 1

--- a/missions/processes/03_pstree_kill/auto.sh
+++ b/missions/processes/03_pstree_kill/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 kill_imp_spell() (
   imp_proc="$(gettext "mischievous_imp" | cut -c1-15)"

--- a/missions/processes/03_pstree_kill/check.sh
+++ b/missions/processes/03_pstree_kill/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
 

--- a/missions/processes/03_pstree_kill/clean.sh
+++ b/missions/processes/03_pstree_kill/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 my_ps | awk -v spell="$(gettext "spell")" '$0 ~ spell {print $1}' | xargs kill -9 2>/dev/null
 my_ps | awk -v imp="$(gettext "mischievous_imp")" '$0 ~ imp {print $1}' | xargs kill -9 2>/dev/null

--- a/missions/processes/03_pstree_kill/fairy/spell.sh
+++ b/missions/processes/03_pstree_kill/fairy/spell.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/missions/processes/03_pstree_kill/imp/spell.sh
+++ b/missions/processes/03_pstree_kill/imp/spell.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/missions/processes/03_pstree_kill/init.sh
+++ b/missions/processes/03_pstree_kill/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _compile() (
 

--- a/missions/processes/03_pstree_kill/mischievous_imp.sh
+++ b/missions/processes/03_pstree_kill/mischievous_imp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/missions/processes/03_pstree_kill/nice_fairy.sh
+++ b/missions/processes/03_pstree_kill/nice_fairy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/missions/processes/03_pstree_kill/static.sh
+++ b/missions/processes/03_pstree_kill/static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Cellar')"
 

--- a/missions/processes/03_pstree_kill/test.sh
+++ b/missions/processes/03_pstree_kill/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 kill_imp_spell() (
   imp_proc="$(gettext "mischievous_imp" | cut -c1-15)"

--- a/missions/stdin_stdout_stderr/01_stdin_additions/auto.sh
+++ b/missions/stdin_stdout_stderr/01_stdin_additions/auto.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh check < "$GSH_TMP/additions.txt"

--- a/missions/stdin_stdout_stderr/01_stdin_additions/check.sh
+++ b/missions/stdin_stdout_stderr/01_stdin_additions/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   exec 3< "$GSH_TMP/arith.txt"

--- a/missions/stdin_stdout_stderr/01_stdin_additions/clean.sh
+++ b/missions/stdin_stdout_stderr/01_stdin_additions/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_TMP/arith.txt" "$GSH_TMP/additions.txt"
 

--- a/missions/stdin_stdout_stderr/01_stdin_additions/init.sh
+++ b/missions/stdin_stdout_stderr/01_stdin_additions/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   results=$GSH_TMP/additions.txt

--- a/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/auto.sh
+++ b/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/auto.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gsh check < "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library')/$(gettext "Mathematics_101")"

--- a/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/check.sh
+++ b/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   time_limit=$(( $(date +%s) + 10 ))

--- a/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/clean.sh
+++ b/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_TMP/arith.txt"
 

--- a/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/init.sh
+++ b/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   cat > "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library')/$(gettext "Greek_Latin_and_other_modern_languages")" <<EOB

--- a/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/static.sh
+++ b/missions/stdin_stdout_stderr/02_stdin_redirection_multiplications/static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library')"
 touch "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library')/$(gettext "Mathematics_101")"

--- a/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/auto.sh
+++ b/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 cd "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office')"
 ls "$(gettext "grimoire")"_* > "$(gettext "Drawer")/$(gettext "inventory.txt")"

--- a/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/check.sh
+++ b/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   office="$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office')"

--- a/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/clean.sh
+++ b/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_TMP/inventory_grimoires"
 (

--- a/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/init.sh
+++ b/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() ( # subshell to avoid changing directory
   office="$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office')"

--- a/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/static.sh
+++ b/missions/stdin_stdout_stderr/03_stdout_redirection_inventory/static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office')/$(gettext "Drawer")"
 sign_file "$MISSION_DIR/ascii-art/candle.txt" "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office')/$(gettext "candle")"

--- a/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/auto.sh
+++ b/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . alt_history_start.sh
 

--- a/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/check.sh
+++ b/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
     pc=$(. fc-lnr.sh | head -n 1)

--- a/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/clean.sh
+++ b/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 
 if [ -f "$GSH_TMP/list_grimoires_RO" ]

--- a/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/init.sh
+++ b/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() ( #subshell to avoid changing directory
   bib="$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office')"

--- a/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/static.sh
+++ b/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/static.sh
@@ -1,3 +1,3 @@
-#!!/bin/sh
+#!/bin/sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office')"

--- a/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/static.sh
+++ b/missions/stdin_stdout_stderr/04_stderr_dev-null_grimoires/static.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Library/Merlin_s_office')"

--- a/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/auto.sh
+++ b/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 key=$(mktemp)
 "$(eval_gettext '$GSH_HOME/Castle/Observatory')"/merlin 2>"$key"

--- a/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/check.sh
+++ b/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_check() (
   secret=$(cat "$GSH_TMP/secret_key")

--- a/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/clean.sh
+++ b/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/clean.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 rm -f "$GSH_TMP/secret_key"

--- a/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/init.sh
+++ b/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 _mission_init() (
   mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Observatory')"

--- a/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/merlin.sh
+++ b/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/merlin.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/static.sh
+++ b/missions/stdin_stdout_stderr/05_stdout_stderr_redirection_merlin/static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Observatory')"
 sign_file "$MISSION_DIR/ascii-art/moon.txt" "$(eval_gettext '$GSH_HOME/Castle/Observatory')/$(gettext "star_chart")"

--- a/scripts/RANDOM
+++ b/scripts/RANDOM
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # to be used as a replacement for bash' $RANDOM
 

--- a/scripts/_gsh_HELP
+++ b/scripts/_gsh_HELP
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/scripts/_gsh_env
+++ b/scripts/_gsh_env
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # display the values of GameShell environment variables
 echo "========================="

--- a/scripts/_gsh_goal
+++ b/scripts/_gsh_goal
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/scripts/_gsh_help
+++ b/scripts/_gsh_help
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/scripts/_gsh_index
+++ b/scripts/_gsh_index
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 n=1
 while read -r mission_dir

--- a/scripts/_gsh_log
+++ b/scripts/_gsh_log
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GSH_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
 

--- a/scripts/_gsh_log.awk
+++ b/scripts/_gsh_log.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env -S awk -f
 
 function human_time(seconds) {
   if (seconds >= 24*3600) {

--- a/scripts/_gsh_pcm
+++ b/scripts/_gsh_pcm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # pcm => "print current mission"
 GSH_CONFIG=$(cd "$(dirname "$0")/../.config"; pwd -P)

--- a/scripts/_gsh_plm
+++ b/scripts/_gsh_plm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # pcm => "print last mission"
 GSH_CONFIG=$(cd "$(dirname "$0")/../.config"; pwd -P)

--- a/scripts/_gsh_protect
+++ b/scripts/_gsh_protect
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 chmod a-rw "$GSH_ROOT"
 chmod a-rw "$GSH_MISSIONS"

--- a/scripts/_gsh_save
+++ b/scripts/_gsh_save
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 ###
 # NOTE: this function should only be called after a "clean"

--- a/scripts/_gsh_stat
+++ b/scripts/_gsh_stat
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GSH_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
 

--- a/scripts/_gsh_stat.awk
+++ b/scripts/_gsh_stat.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env -S awk -f
 
 function _(s) {
     sprintf(". gsh_gettext.sh; gettext '%s'", s) | getline msg;

--- a/scripts/_gsh_systemconfig
+++ b/scripts/_gsh_systemconfig
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # display some info about the system
 echo "========================="

--- a/scripts/_gsh_unprotect
+++ b/scripts/_gsh_unprotect
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 chmod "$(umask -S)" "$GSH_ROOT"
 chmod "$(umask -S)" "$GSH_MISSIONS"

--- a/scripts/_gsh_version
+++ b/scripts/_gsh_version
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/scripts/_gsh_welcome
+++ b/scripts/_gsh_welcome
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/scripts/admin_mode
+++ b/scripts/admin_mode
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/scripts/box.sh
+++ b/scripts/box.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 
 cd -P "$(dirname "$0")"

--- a/scripts/check_file
+++ b/scripts/check_file
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # check the hash on the first line of a file
 # the hash is expected to sign the content of the file, a random number (given

--- a/scripts/checksum
+++ b/scripts/checksum
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # computes a checksum of a string
 # with no argument, reads the string from STDIN

--- a/scripts/color_echo
+++ b/scripts/color_echo
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 case "$1" in
   black   | bk) color=0; shift;;

--- a/scripts/copy_bin
+++ b/scripts/copy_bin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # create a script to call a mission executable with appropriate context:
 # correct TEXTDOMAIN (for translations) and MISSION_DIR (to use data files)
@@ -26,7 +26,7 @@ copy_bin() {
     target=$target/$(basename "$source")
   fi
   cat > "$target" <<EOH
-#!/bin/sh
+#!/usr/bin/env sh
 export MISSION_DIR="\$GSH_ROOT/${MISSION_DIR#$GSH_ROOT/}"
 export TEXTDOMAIN="$DOMAIN"
 exec "\$GSH_ROOT/${1#$GSH_ROOT/}" "\$@"

--- a/scripts/create_boxes_data.awk
+++ b/scripts/create_boxes_data.awk
@@ -1,4 +1,4 @@
-#!/bin/awk -f
+#!/usr/bin/env -S awk -f
 BEGIN {
   t["T"] = 1;
   t["M"] = 2;

--- a/scripts/generate_rcfile
+++ b/scripts/generate_rcfile
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . gsh_gettext.sh
 

--- a/scripts/gsh_gettext.sh
+++ b/scripts/gsh_gettext.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ -z "$GSH_NO_GETTEXT" ]
 then

--- a/scripts/mainshell.sh
+++ b/scripts/mainshell.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # this file must be SOURCED, it will return 0 (true) if the current PID is the
 # same as $$, and 1 (false) otherwise

--- a/scripts/make_index
+++ b/scripts/make_index
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GSH_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
 GSH_MISSIONS=$GSH_ROOT/missions

--- a/scripts/missiondir
+++ b/scripts/missiondir
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GSH_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
 GSH_MISSIONS=$GSH_ROOT/missions

--- a/scripts/missionname
+++ b/scripts/missionname
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GSH_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
 GSH_MISSIONS=$GSH_ROOT/missions

--- a/scripts/mktemp
+++ b/scripts/mktemp
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GSH_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
 PATH=$PATH:"$GSH_ROOT/scripts"

--- a/scripts/pager
+++ b/scripts/pager
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 TEXTDOMAIN=gsh
 

--- a/scripts/parchment
+++ b/scripts/parchment
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # draw a parchment around a text file
 # usage:

--- a/scripts/progress_bar
+++ b/scripts/progress_bar
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # display a small animation until the given PID stops
 

--- a/scripts/random_string
+++ b/scripts/random_string
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GSH_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
 GSH_CONFIG=$GSH_ROOT/.config

--- a/scripts/readlink-f
+++ b/scripts/readlink-f
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # inspired by cf https://stackoverflow.com/questions/7665/how-to-resolve-symbolic-links-in-a-shell-script
 # NOTE that you need traversal access to directories...

--- a/scripts/reflow.awk
+++ b/scripts/reflow.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env -S awk -f
 
 function usage() {
 }

--- a/scripts/rm
+++ b/scripts/rm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GSH_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
 

--- a/scripts/rm
+++ b/scripts/rm
@@ -31,5 +31,5 @@ then
   done
 fi
 
-/bin/rm "$@"
+PATH="${PATH_NO_GSH}" rm "$@"
 

--- a/scripts/sed-i
+++ b/scripts/sed-i
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 ## posix way to do sed "in place"
 

--- a/scripts/seq
+++ b/scripts/seq
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 display_help() {
   cat <<'EOH' >&2

--- a/scripts/sign_file
+++ b/scripts/sign_file
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 PATH=$PATH:$(dirname "$0")
 

--- a/scripts/textdomainname
+++ b/scripts/textdomainname
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GSH_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
 "$GSH_ROOT/scripts/missionname" "$1" | sed 's|/|,|g'

--- a/scripts/treasure_message
+++ b/scripts/treasure_message
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # display a treasure message
 

--- a/scripts/wcwidth.awk
+++ b/scripts/wcwidth.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env -S awk -f
 
 # This AWK library provides 4 functions for working with UTF-8 strings:
 #

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # warning about "echo $(cmd)", used many times with echo "$(gettext ...)"
 # shellcheck disable=SC2005
@@ -539,7 +539,7 @@ then
   # NOTE, the above works in bash, but when running the following script with
   # GSH_SHELL=zsh, it fails with "zsh: suspended (tty output)"
   # ======== script =======
-  # #!/bin/sh
+  # #!/usr/bin/env sh
   # ./gameshell.sh -qc "gsh exit"; ./gameshell.sh -qc "gsh exit"
   # =======================
   # FIX: don't start the shell in interactive mode, and source the rcfile

--- a/utils/archive.sh
+++ b/utils/archive.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 export GSH_ROOT=$(dirname "$0")/..
 . $GSH_ROOT/lib/profile.sh

--- a/utils/new_mission.sh
+++ b/utils/new_mission.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 export GSH_ROOT="$(dirname "$0")/.."
 
@@ -20,7 +20,7 @@ EOH
 new_static_file() {
   MISSION_DIR="$1"
   cat <<'EOF' > "$MISSION_DIR"/static.sh
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This file is not required: it is sourced once when initialising a GameShell
 # game, and whenever the corresponding missions is (re)started.
@@ -51,7 +51,7 @@ EOF
 new_goal_gettext_file() {
   MISSION_DIR="$1"
   cat <<'EOF' > "$MISSION_DIR"/_goal.sh
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This file is not required. It can be used to generate dynamic goal messages.
 # If you need that, rename the file to 'goal.sh'.
@@ -88,7 +88,7 @@ EOF
 new_init_file() {
   MISSION_DIR="$1"
   cat <<'EOF' > "$MISSION_DIR"/init.sh
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This file is not required: it is sourced every time the mission is started.
 # Since it is sourced every time the mission is restarted, it can generate
@@ -117,7 +117,7 @@ EOF
 new_check_file() {
   MISSION_DIR="$1"
   cat <<'EOF' > "$MISSION_DIR"/check.sh
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This file is required. It is sourced when checking the goal of the mission
 # has been achieved.
@@ -139,7 +139,7 @@ EOF
 new_auto_file() {
   MISSION_DIR="$1"
   cat <<'EOF' > "$MISSION_DIR"/_auto.sh
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This file is not required. When it exists, it is used to automatically
 # validate the mission. It should end with a succesful `gsh check` command.
@@ -152,7 +152,7 @@ EOF
 new_clean_file() {
   MISSION_DIR="$1"
   cat <<'EOF' > "$MISSION_DIR"/_clean.sh
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This file is not required. When it exists, it is used to clean the mission,
 # for example on completion, or when restarting it.
@@ -166,7 +166,7 @@ EOF
 new_treasure_file() {
   MISSION_DIR="$1"
   cat <<'EOF' > "$MISSION_DIR"/_treasure.sh
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This file is not required. When it exists, it is sourced on successfull
 # completion of the mission and is added to the global configuration.
@@ -197,7 +197,7 @@ EOF
 new_gettext_treasure_msg_file() {
   MISSION_DIR="$1"
   cat <<'EOF' > "$MISSION_DIR"/_treasure-msg.sh
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This file is not required. It can be used to generate dynamic treasure
 # messages.
@@ -221,7 +221,7 @@ EOF
 new_test_file() {
   MISSION_DIR="$1"
   cat <<'EOF' > "$MISSION_DIR"/_test.sh
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This file is not required: it is sourced by the command "gsh test" for
 # testing during development.


### PR DESCRIPTION
### Context
Hi and first of all, thanks for your work on GameShell!

While I was investigating this project to determine whether we can use for teaching purposes at our university, I was not able to run it on my machine (log below), which runs a NixOS linux.

NixOS does not put executable files in `/bin` nor `/usr/bin` but keep them in separate directories and sets `$PATH` accordingly. The modifications of this PR made GameShell run on my machine by avoiding the use of absolute paths for external executable files.

### Log of failed first execution (before modifications)
```
/tmp/gameshell/scripts/rm: line 34: /bin/rm: No such file or directory
Error: a least one base function is not working properly.
Aborting!
```

### Modifications done
1. env is used instead of absolute paths in shabangs.
    env is the standard tool to look for the location of executable files ; env essentially traverses `$PATH` to look for the first matching executable. env is located in `/usr/bin/env` on all systems I know (including NixOS, that ony has two executable files accessible from a common absolute path: `/bin/sh` for booting shenanigans and `/usr/bin/env` to find other executables).
    - `env -S` is used to give the `-f` argument to `awk`. the option may not be available on all systems but should work on any recent linux (GNU coreutils 8.30+, released on 2018-07-01), recent macOS and freebsd.
2. keep a copy of `PATH` before its modification by GameShell, so that we can run *real* commands from the user-given `PATH`.
3. in rm's wrapper script, run `rm` with a specific `PATH` (the user-given `PATH`) instead of calling it from an absolute location.

### Tests done
1. I successfully could create a gameshell archive by running `utils/archive.sh` with no arguments.
2. I successfully ran the new archive and did missions 1 and 2.

I did this on two setups:
- my machine (a NixOS linux on x86-64 without specific hacks, configuration fully defined [there (using the `nyx` machine from `flake.nix`)](https://github.com/mpoquet/nixos-config))
- a Debian. I used the default Grid'5000 environment on x86-64 as of 2022-11-07 : `Linux dahu-6.grenoble.grid5000.fr 5.10.0-18-amd64 #1 SMP Debian 5.10.140-1 (2022-09-02) x86_64 GNU/Linux`.