### PR TITLE
Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+../Dockerfile

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "GameShell Dev Container",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "Dockerfile"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from debian:stable
+FROM debian:stable
 
 ###
 # install dependencies

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ you want to run X programs from inside GameShell. Refer to [this
 section](./doc/deps.md#running-GameShell-from-a-docker-container) of the user
 manual.
 
+Github Codespaces
+-----------------
+
+This repository features a [devcontainer.json](https://containers.dev/) enabling 
+GameShell to be run directly from a [Github Codespace](https://github.com/features/codespaces).
+
+Once the Codespace is launched, you can run GameShell in the terminal with:
+
+```sh
+bash start.sh
+```
+
+To get the same experience on your local machine without the limitations/cost
+of Codespaces see [the Dev Container docs](https://containers.dev/supporting#tools)
 
 Documentation
 -------------


### PR DESCRIPTION
See README changes

You should be able to preview this experience from [my repo](https://github.com/er2/GameShell/tree/devcontainer).

![image](https://github.com/phyver/GameShell/assets/4515131/b7d0baf0-267d-49d5-8059-14f0952d9469)


Changing `from` to `FROM` in `Dockerfile` was necessary to fix a weird bug I encountered on github codespaces but not locally with the devcontainers cli.