### PR TITLE
Fix issue with the semaphore file if multiple users are using the same machine

### DIFF
--- a/missions/processes/02_ps_kill_signal/clean.sh
+++ b/missions/processes/02_ps_kill_signal/clean.sh
@@ -4,5 +4,6 @@ kill -9 $(cat "$GSH_TMP/spell-term.pids" 2>/dev/null) 2>/dev/null
 kill -9 $(cat "$GSH_TMP/spell.pids" 2>/dev/null) 2>/dev/null
 my_ps | awk '/sleep|tail/ {print $1}' | xargs kill -9 2>/dev/null
 rm -f "$GSH_TMP/spell-term.pids" "$GSH_TMP/spell.pids" "$GSH_TMP/$(gettext "spell")"
-
+rm --system -f /dev/shm/sem.writing_sem_${USER}
+rm --system -f /dev/shm/sem.printing_sem_${USER}
 [ -n "$GSH_NON_INTERACTIVE" ] || set -o monitor  # monitor background processes (default)

--- a/missions/processes/02_ps_kill_signal/spell.c
+++ b/missions/processes/02_ps_kill_signal/spell.c
@@ -119,11 +119,22 @@ int main()
     }
 
     // Initialize semaphores.
-    printing_sem = sem_open("/printing_sem", O_CREAT, 0644, 1);
+    //
+     char login[20];
+     getlogin_r(login, 20);
+     char sem_path[30];
+     strcpy(sem_path, "/printing_sem_");
+     strcat(sem_path,login);
+
+    printing_sem = sem_open(sem_path, O_CREAT, 0644, 1);
     if (printing_sem == SEM_FAILED)
         return 1;
 
-    writing_sem = sem_open("/writing_sem", O_CREAT, 0644, 1);
+
+     strcpy(sem_path, "/writing_sem_");
+     strcat(sem_path,login);
+
+    writing_sem = sem_open(sem_path, O_CREAT, 0644, 1);
     if (writing_sem == SEM_FAILED)
         return 1;
 

--- a/missions/processes/03_pstree_kill/clean.sh
+++ b/missions/processes/03_pstree_kill/clean.sh
@@ -15,6 +15,7 @@ rm -f "$GSH_TMP/fairy.pid"
 rm -f "$GSH_TMP/imp.pid"
 rm -f "$GSH_TMP/$(gettext "nice_fairy")"
 rm -f "$GSH_TMP/$(gettext "mischievous_imp")"
+rm --system -f /dev/shm/sem.writing_sem_${USER}
 (
   cd "$(eval_gettext '$GSH_HOME/Castle/Cellar')"
   # keep at most 10 snowflakes

--- a/missions/processes/03_pstree_kill/spell.c
+++ b/missions/processes/03_pstree_kill/spell.c
@@ -124,7 +124,14 @@ int main()
     /* printf(">>> log_file = '%s'\n", log_file); */
     wordfree(&result);
 
-    writing_sem = sem_open("/writing_sem", O_CREAT, 0644, 1);
+    char login[20];
+    getlogin_r(login, 20);
+    char sem_path[30];
+    strcpy(sem_path, "/writing_sem_");
+    strcat(sem_path,login);
+
+
+    writing_sem = sem_open(sem_path, O_CREAT, 0644, 1);
     if (writing_sem == SEM_FAILED)
         return 1;
 


### PR DESCRIPTION
This PR, is expected to fix an issue detected for the level: processes/02_ps_kill_signal

The file /dev/shm/sem.printing_sem is the same for all users, and therefore the second user (of the same machine) can not create it since it belongs to another user. Additionally the file was never removed.

So this PR (done with the help of @damienfrancois):
1) change the name of the file to include the login of the user
2) edit clean.sh to remove such file 

Thanks a lot for this wonderful game,

Olivier
