### PR TITLE
Mission 3 : adding initial position and error messages

### DIFF
--- a/doc/mission.md
+++ b/doc/mission.md
@@ -201,7 +201,7 @@ Useful commands
 ===============
 
 cd PLACE
-  Move to the given place, if accessible from you current location.
+  Move to the given place, if accessible from your current location.
 ```
 
 For uniformity, meta-variables in commands should be in UPPERCASE.

--- a/missions/basic/03_cd_HOME_throne/check.sh
+++ b/missions/basic/03_cd_HOME_throne/check.sh
@@ -8,9 +8,23 @@ _mission_check() {
 
   ppc=$(. fc-lnr.sh | sed -n '2p;3q')
 
-  # FIXME: also accept other commands to go back to the starting point?
-  # FIXME: add an error message
-  [ "$goal" = "$current" ] && [  "$ppc" = "cd" ]
+  # Accepts only "cd" and "cd ~". "cd ../../../../" and variants are not valid.
+  if [ "$ppc" != "cd" ] && [ "$ppc" != "cd ~" ]; then
+    if [ "$ppc" =~ "cd ../*" ]; then
+      echo "$(gettext "The command to go to the starting point is too complicated.")"
+    else
+      echo "$(gettext "The previous to last command must take you to the starting point.")"
+    fi
+    return 1
+  fi
+
+  # Verify the current location
+  if [ "$goal" != "$current" ]; then
+    echo "$(gettext "You are not in the throne room.")"
+    return 1
+  fi
+
+  return 0
 }
 
 _mission_check

--- a/missions/basic/03_cd_HOME_throne/goal/fr.txt
+++ b/missions/basic/03_cd_HOME_throne/goal/fr.txt
@@ -19,7 +19,7 @@ Commandes utiles
 ================
 
 cd
-  Revient au lieu initial.
+  Revient au point de départ.
 
 cd LIEU1/LIEU2/LIEU3
   Fait plusieurs déplacements avec une commande.

--- a/missions/basic/03_cd_HOME_throne/i18n/en.po
+++ b/missions/basic/03_cd_HOME_throne/i18n/en.po
@@ -7,6 +7,9 @@ msgstr  "Content-Type: text/plain; charset=UTF-8\n"
 msgid   "$GSH_HOME/Castle/Main_building/Throne_room"
 msgstr  "$GSH_HOME/Castle/Main_building/Throne_room"
 
+msgid   "$GSH_HOME/Castle/Cellar"
+msgstr  "$GSH_HOME/Castle/Cellar"
+
 # path for the text file containing the goal
 msgid   "$MISSION_DIR/goal/en.txt"
 msgstr  "$MISSION_DIR/goal/en.txt"
@@ -18,3 +21,16 @@ msgstr  "$MISSION_DIR/skip/en.txt"
 # path for the text file containing the treasure message
 msgid   "$MISSION_DIR/treasure-msg/en.txt"
 msgstr  "$MISSION_DIR/treasure-msg/en.txt"
+
+# Message for current position
+msgid   "Current position:"
+msgstr  "Current position:"
+
+msgid   "The command to go to the starting point is too complicated."
+msgstr  "The command to go to the starting point is too complicated."
+
+msgid   "The previous to last command must take you to the starting point."
+msgstr  "The previous to last command must take you to the starting point."
+
+msgid   "You are not in the throne room."
+msgstr  "You are not in the throne room."

--- a/missions/basic/03_cd_HOME_throne/i18n/fr.po
+++ b/missions/basic/03_cd_HOME_throne/i18n/fr.po
@@ -6,6 +6,9 @@ msgstr  "Content-Type: text/plain; charset=UTF-8\n"
 msgid   "$GSH_HOME/Castle/Main_building/Throne_room"
 msgstr  "$GSH_HOME/Chateau/Batiment_principal/Salle_du_trone"
 
+msgid   "$GSH_HOME/Castle/Cellar"
+msgstr  "$GSH_HOME/Chateau/Cave"
+
 # path for the text file containing the goal
 msgid   "$MISSION_DIR/goal/en.txt"
 msgstr  "$MISSION_DIR/goal/fr.txt"
@@ -17,3 +20,16 @@ msgstr  "$MISSION_DIR/skip/fr.txt"
 # path for the text file containing the treasure message
 msgid   "$MISSION_DIR/treasure-msg/en.txt"
 msgstr  "$MISSION_DIR/treasure-msg/fr.txt"
+
+# Message for current position
+msgid   "Current position:"
+msgstr  "Position actuelle :"
+
+msgid   "The command to go to the starting point is too complicated."
+msgstr  "La commande pour retourner au point de départ est trop compliquée."
+
+msgid   "The previous to last command must take you to the starting point."
+msgstr  "L'avant-dernière commande doit vous ramener au point de départ."
+
+msgid   "You are not in the throne room."
+msgstr  "Vous n'êtes pas dans la salle du trône."

--- a/missions/basic/03_cd_HOME_throne/i18n/it.po
+++ b/missions/basic/03_cd_HOME_throne/i18n/it.po
@@ -17,6 +17,9 @@ msgstr ""
 msgid "$GSH_HOME/Castle/Main_building/Throne_room"
 msgstr "$GSH_HOME/Castello/Palazzo_principale/Sala_del_trono"
 
+msgid "$GSH_HOME/Castle/Cellar"
+msgstr "$GSH_HOME/Castello/Cantina"
+
 # path for the text file containing the goal
 msgid "$MISSION_DIR/goal/en.txt"
 msgstr "$MISSION_DIR/goal/it.txt"

--- a/missions/basic/03_cd_HOME_throne/i18n/template.pot
+++ b/missions/basic/03_cd_HOME_throne/i18n/template.pot
@@ -6,6 +6,9 @@ msgstr  "Content-Type: text/plain; charset=UTF-8\n"
 msgid   "$GSH_HOME/Castle/Main_building/Throne_room"
 msgstr  ""
 
+msgid   "$GSH_HOME/Castle/Cellar"
+msgstr  ""
+
 # path for the text file containing the goal
 msgid   "$MISSION_DIR/goal/en.txt"
 msgstr  ""
@@ -16,4 +19,17 @@ msgstr  ""
 
 # path for the text file containing the treasure message
 msgid   "$MISSION_DIR/treasure-msg/en.txt"
+msgstr  ""
+
+# Message for current position
+msgid   "Current position:"
+msgstr  ""
+
+msgid   "The command to go to the starting point is too complicated."
+msgstr  ""
+
+msgid   "The previous to last command must take you to the starting point."
+msgstr  ""
+
+msgid   "You are not in the throne room."
 msgstr  ""

--- a/missions/basic/03_cd_HOME_throne/init.sh
+++ b/missions/basic/03_cd_HOME_throne/init.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+cd "$GSH_HOME/Castle/Main_tower/First_floor/Second_floor/Top_of_the_tower"
+echo "Current position: $(pwd)"

--- a/missions/basic/03_cd_HOME_throne/init.sh
+++ b/missions/basic/03_cd_HOME_throne/init.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
-cd "$GSH_HOME/Castle/Main_tower/First_floor/Second_floor/Top_of_the_tower"
-echo "Current position: $(pwd)"
+cd "$(eval_gettext '$GSH_HOME/Castle/Cellar')"
+echo "$(gettext "Current position:") $(pwd)"

--- a/missions/basic/03_cd_HOME_throne/static.sh
+++ b/missions/basic/03_cd_HOME_throne/static.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
-mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_tower/First_floor/Second_floor/Top_of_the_tower')"
+mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Cellar')"
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room')"

--- a/missions/basic/03_cd_HOME_throne/static.sh
+++ b/missions/basic/03_cd_HOME_throne/static.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
 
+mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_tower/First_floor/Second_floor/Top_of_the_tower')"
 mkdir -p "$(eval_gettext '$GSH_HOME/Castle/Main_building/Throne_room')"


### PR DESCRIPTION
Adding `init.sh` to mission #3 so we start from the cellar (end position of mission #2).
Otherwise, after a restart we are already in `World/` so the first goal is a bit strange.
Also added a message stating the current position when starting/resetting the level.

Now accepting also `cd ~` (before, was only `cd`) for the first goal, to go back to the starting point.

Added error messages to give more information after seeing some students struggle with this mission :
- stating the command is too complicated if using e.g. `cd ../../`
- explaining the previous to last command must go back to starting point
- error message if current position is not in the throne room.