### PR TITLE
Fix missing '.' in explanation of find command

### DIFF
--- a/missions/finding_files_maze/03_find_1/goal/en.txt
+++ b/missions/finding_files_maze/03_find_1/goal/en.txt
@@ -8,7 +8,7 @@ them to your chest.
 Useful commands
 ===============
 
-find CONDITION
+find . CONDITION
   Search for files satisfying the condition, starting from your 
   current working directory.
 

--- a/missions/finding_files_maze/03_find_1/goal/fr.txt
+++ b/missions/finding_files_maze/03_find_1/goal/fr.txt
@@ -8,7 +8,7 @@ déplacez les dans votre coffre.
 Commandes utiles
 ================
 
-find CONDITION
+find . CONDITION
   Cherche des fichiers à partir du répertoire courant.
 
   Les conditions peuvent porter sur le nom des fichiers, leur 

--- a/missions/finding_files_maze/03_find_1/goal/it.txt
+++ b/missions/finding_files_maze/03_find_1/goal/it.txt
@@ -7,7 +7,7 @@ nella tua cassa.
 Comandi utili
 =============
 
-find CONDIZIONE
+find . CONDIZIONE
   Cerca file che soddisfano le condizioni, partendo dalla cartella 
   corrente.
 


### PR DESCRIPTION
Hi,

First thanks a lot for this very nice and very well done game ! I have successfully integrated it in my lecture on shell, students really appreciate.

Students struggled on *find* mission as the there is a missing dot in the useful commands. This MR fix it.